### PR TITLE
return number of data points as u64

### DIFF
--- a/src/online.rs
+++ b/src/online.rs
@@ -82,8 +82,8 @@ impl OnlineStats {
     }
 
     /// Returns the number of data points.
-    pub fn len(&self) -> usize {
-        self.size as usize
+    pub fn len(&self) -> u64 {
+        self.size
     }
 }
 


### PR DESCRIPTION
the length is not related to size of memory, so `usize` is not needed here. And on non 64-bit machines this can lead to data loss.
