### PR TITLE
Fix the Cargo.toml example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cargo test
 You can also add `rust-stats` as a dependency to your project's `Cargo.toml`:
 
 ```toml
-[dependencies.rust-stats]
+[dependencies.streaming-stats]
 git = "git://github.com/BurntSushi/rust-stats"
 ```
 


### PR DESCRIPTION
The name of the crate has changed, so this PR updates the dependency example in README so that it uses the name 'streaming-stats'.
