### PR TITLE
Fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Dual-licensed under MIT or the [UNLICENSE](http://unlicense.org).
 ### Documentation
 
 Some documentation exists here:
-[http://burntsushi.net/rustdoc/stats/](http://burntsushi.net/rustdoc/stats/).
+[https://docs.rs/streaming-stats](https://docs.rs/streaming-stats).
 
 
 ### Installation


### PR DESCRIPTION
The README was pointing to a link that was redirecting to the wrong (old?) docs.rs crate, so this just changes the README to link to the correct docs.rs link.