### PR TITLE
Fix broken documentation link on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "streaming-stats"
-version = "0.2.2"  #:version
+version = "0.2.3"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "Experimental crate for computing basic statistics on streams."
-documentation = "http://burntsushi.net/rustdoc/stats/"
+documentation = "https://docs.rs/streaming-stats"
 homepage = "https://github.com/BurntSushi/rust-stats"
 repository = "https://github.com/BurntSushi/rust-stats"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streaming-stats"
-version = "0.2.3"  #:version
+version = "0.2.2"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "Experimental crate for computing basic statistics on streams."
 documentation = "https://docs.rs/streaming-stats"


### PR DESCRIPTION
http://burntsushi.net/rustdoc/stats/ is forwarded to https://docs.rs/stats/0.0.1/stats/ which is a complete different crate.

Fixes #6